### PR TITLE
Add error emit on message block notice

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -98,7 +98,6 @@ const TwitchBot = class TwitchBot extends EventEmitter {
   checkForError(event) {
     /* Login Authentication Failed */
     if(event.includes('Login authentication failed')) {
-
       this.irc.emit('error', {
         message: 'Login authentication failed'
       })
@@ -107,6 +106,12 @@ const TwitchBot = class TwitchBot extends EventEmitter {
     if(event.includes('Improperly formatted auth')) {
       this.irc.emit('error', {
         message: 'Improperly formatted auth'
+      })
+    }
+    /* Notice about blocked messages */
+    if(event.includes('Your message was not sent because you are sending messages too quickly')) {
+      this.irc.emit('error', {
+        message: 'Your message was not sent because you are sending messages too quickly'
       })
     }
   }


### PR DESCRIPTION
It's fairly rare but i was so confused that my bot could not execute a command twice on external channels because it answered too fast, so i added a check for it ;)