### PR TITLE
Issue #17 : Fix for CLEARCHAT event in parsing username

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -50,7 +50,8 @@ module.exports = {
     else parsed.type = 'ban'
 
     parsed.channel = channel
-    parsed.target_username = target_username.replace(/\r\n/g, '')
+    if (target_username)
+      parsed.target_username = target_username.replace(/\r\n/g, '')
 
     /* TODO: This needs a proper fix */
     parsed.tmi_sent_ts = parseInt(parsed.tmi_sent_ts)

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -50,8 +50,9 @@ module.exports = {
     else parsed.type = 'ban'
 
     parsed.channel = channel
-    if (target_username)
+    if (target_username) {
       parsed.target_username = target_username.replace(/\r\n/g, '')
+    }
 
     /* TODO: This needs a proper fix */
     parsed.tmi_sent_ts = parseInt(parsed.tmi_sent_ts)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "twitch-bot",
-  "version": "1.0.9",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -90,11 +90,6 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
       "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
       "dev": true
-    },
-    "dotenv": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
-      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
     },
     "escape-string-regexp": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha test/parser.js test/test.js test/socketstub.js --timeout 5000",
-    "teststub" : "mocha test/socketstub.js"
+    "teststub": "mocha test/socketstub.js"
   },
   "repository": {
     "type": "git",

--- a/test/test.js
+++ b/test/test.js
@@ -8,7 +8,7 @@ const socketstub = require('./socketstub')
 
 describe('TwitchBot()', () => {
   it('should create a new Bot instance', () => {
-    const bot = utils.createBotInstance({})
+    const bot = utils.createBotInstance({username: 'Test', oauth: '123435', channels: ['twitch']})
     expect(bot).to.be.an.instanceOf(TwitchBot)
     bot.close()
   })
@@ -29,8 +29,8 @@ describe('TwitchBot()', () => {
   })
 
   it('should normalize the channel name', () => {
-    const bot = utils.createBotInstance({ channels: ['Channel'] })
-    const bot2 = utils.createBotInstance({ channels: ['#ChanneL'] })
+    const bot = utils.createBotInstance({ username: 'Test', oauth: '123435', channels: ['Channel'] })
+    const bot2 = utils.createBotInstance({ username: 'Test', oauth: '123435', channels: ['#ChanneL'] })
     expect(bot.channels[0]).to.equal('#channel')
     expect(bot2.channels[0]).to.equal('#channel')
     bot.close()


### PR DESCRIPTION
When issuing a `/clear` command in chat, the fact that the code is attempting to parse out a non-existing username causes the code  to crash.  Also fixed issue with a couple of tests.  All should pass now.