### PR TITLE
Register capabilities before join

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -52,11 +52,12 @@ const TwitchBot = class TwitchBot extends EventEmitter {
     this.listen()
     this.writeIrcMessage("PASS " + this.oauth)
     this.writeIrcMessage("NICK " + this.username)
-    this.channels.forEach(c => this.join(c))
 
     this.writeIrcMessage("CAP REQ :twitch.tv/membership")
     this.writeIrcMessage("CAP REQ :twitch.tv/tags")
     this.writeIrcMessage("CAP REQ :twitch.tv/commands")
+
+    this.channels.forEach(c => this.join(c))
 
   }
 

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -53,11 +53,13 @@ const TwitchBot = class TwitchBot extends EventEmitter {
     this.writeIrcMessage("PASS " + this.oauth)
     this.writeIrcMessage("NICK " + this.username)
 
-    this.writeIrcMessage("CAP REQ :twitch.tv/membership")
     this.writeIrcMessage("CAP REQ :twitch.tv/tags")
+    this.channels.forEach(c => this.join(c))
+    
+    this.writeIrcMessage("CAP REQ :twitch.tv/membership")
     this.writeIrcMessage("CAP REQ :twitch.tv/commands")
 
-    this.channels.forEach(c => this.join(c))
+
 
   }
 


### PR DESCRIPTION
Sometimes a PRIVMSG can slip through before capabilities are registered. This can cause issues when parsing the message. Moved join after registering capabilities to ensure consistent message format.