### PR TITLE
Updated README example to use proper event callback registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ const Bot = new TwitchBot({
   channels: ['twitch']
 })
 
-Bot.on('join', (channel) => {
+Bot.on('join', channel => {
   console.log(`Joined channel: ${channel}`)
 })
 

--- a/README.md
+++ b/README.md
@@ -17,18 +17,20 @@ const Bot = new TwitchBot({
   channels: ['twitch']
 })
 
-Bot.on('join', () => {
-
-  Bot.on('message', chatter => {
-    if(chatter.message === '!test') {
-      Bot.say('Command executed! PogChamp')
-    }
-  })
+Bot.on('join', (channel) => {
+  console.log(`Joined channel: ${channel}`)
 })
 
 Bot.on('error', err => {
   console.log(err)
 })
+
+Bot.on('message', chatter => {
+  if(chatter.message === '!test') {
+    Bot.say('Command executed! PogChamp')
+  }
+})
+
 ```
 
 ## Index


### PR DESCRIPTION
Previously, the example instructed users to register the message callback in the event callback for the channel join event, resulting in multiple callbacks being registered for each joined channel.

Helps to prevent mistakes like in #30 